### PR TITLE
Fix aliasing error for continuous attributes

### DIFF
--- a/skeLCS/DataManagement.py
+++ b/skeLCS/DataManagement.py
@@ -6,7 +6,7 @@ class DataManagement:
         self.savedRawTrainingData = [dataFeatures,dataPhenotypes]
         self.numAttributes = dataFeatures.shape[1]  # The number of attributes in the input file.
         self.attributeInfoType = [0]*self.numAttributes #stores false (d) or true (c) depending on its type, which points to parallel reference in one of the below 2 arrays
-        self.attributeInfoContinuous = [[0,0]]*self.numAttributes #stores continuous ranges and NaN otherwise
+        self.attributeInfoContinuous = [[np.inf,-np.inf] for _ in range(self.numAttributes)] #stores continuous ranges and NaN otherwise
         self.attributeInfoDiscrete = [0]*self.numAttributes #stores arrays of discrete values or NaN otherwise.
         for i in range(0,self.numAttributes):
             self.attributeInfoDiscrete[i] = AttributeInfoDiscreteElement()


### PR DESCRIPTION
Current implementation creates a list of aliases to the same list - when features are in wildly different ranges causes the range of every feature to be the range of the largest feature. This change removes the aliasing error, while also removing the error of not being able to have a minimum in the range that is greater than 0, or a maximum less than 0.